### PR TITLE
Fix missing check of reg field

### DIFF
--- a/src/dts_utils/dts.py
+++ b/src/dts_utils/dts.py
@@ -57,7 +57,13 @@ class Dts:
         nodes = []
         for n in self._dt.node_iter():
             node = Node(n)
-            if node.reg and node.reg[0] != 0 and node.reg[1] > 0:
+            if (
+                node.reg
+                and isinstance(node.reg, list)
+                and len(node.reg) >= 2
+                and node.reg[0] != 0
+                and node.reg[1] > 0
+            ):
                 nodes.append(node)
         return nodes
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ select = C, D, E, F, W, B, B9, DOC
 # As doc lint is a new feature, this is widely incomplete.
 # We should ignore D1xx (missing docstring) temporarilly.
 # Once everything is documented, re-enable this error.
-ignore = D1, E203, E704
+ignore = D1, E203, E704, W503
 max-line-length = 100
 exclude = .git, .github, __pycache__, build, dist, .eggs, .tox, venv, venv*, .venv, .venv*, reports, .mypy_cache, doc
 # pydoclint (flake8) plugin opt --style


### PR DESCRIPTION
DTS parsing used to fail when some nodes had only entry in the reg field. This PR add a check on the list size.